### PR TITLE
feat(examples): add pruna and nano banana pro image model examples

### DIFF
--- a/ai-sdk/getting-started/edit-image-nano-banana-pro.js
+++ b/ai-sdk/getting-started/edit-image-nano-banana-pro.js
@@ -1,0 +1,42 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { experimental_generateImage as generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("image edit (nano banana pro) with Runpod AI SDK Provider\n");
+
+async function main() {
+  const imageUrl =
+    process.argv[2] ||
+    "https://image.runpod.ai/assets/google/nano-banana-pro-edit-asset.jpg";
+
+  const prompt =
+    process.argv[3] ||
+    "Add Christmas decorations to this cozy small town: twinkling Christmas lights along rooflines and windows, festive wreaths on front doors, Christmas trees visible through warm glowing windows, vintage street lamps wrapped in evergreen garlands with red bows, gazebo in the town square decorated with lights and ornaments, picket fences adorned with festive decorations, gentle snowfall, soft blanket of snow on rooftops and streets, warm holiday atmosphere with Christmas lights creating a magical glow, maintaining the cozy Christmas aesthetic.";
+
+  const { image } = await generateImage({
+    model: runpod.imageModel("google/nano-banana-pro-edit"),
+    prompt,
+    providerOptions: {
+      runpod: {
+        images: [imageUrl],
+        resolution: "1k",
+        output_format: "jpeg",
+        enable_base64_output: false,
+        enable_sync_mode: false,
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `edited-image-nano-banana-pro-${timestamp}.jpg`;
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/edit-image-pruna.js
+++ b/ai-sdk/getting-started/edit-image-pruna.js
@@ -1,0 +1,37 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { experimental_generateImage as generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("image edit (pruna p-image-edit) with Runpod AI SDK Provider\n");
+
+async function main() {
+  const imageUrl =
+    process.argv[2] || "https://image.runpod.ai/preview/pruna/p-image-t2i.png";
+
+  const { image } = await generateImage({
+    model: runpod.imageModel("pruna/p-image-edit"),
+    prompt: "the lion is dressed up as santa claus, watercolor painting style",
+    providerOptions: {
+      runpod: {
+        images: [imageUrl],
+        aspect_ratio: "match_input_image",
+        seed: -1,
+        disable_safety_checker: false,
+        enable_sync_mode: false,
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `edited-image-pruna-${timestamp}.png`;
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/generate-image-pruna.js
+++ b/ai-sdk/getting-started/generate-image-pruna.js
@@ -1,0 +1,35 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { experimental_generateImage as generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("image generation (pruna t2i) with Runpod AI SDK Provider\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.imageModel("pruna/p-image-t2i"),
+    prompt: "A majestic lion standing on a rocky cliff at sunset",
+    providerOptions: {
+      runpod: {
+        aspect_ratio: "16:9",
+        enable_safety_checker: true,
+        seed: 0,
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `generated-image-pruna-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});
+

--- a/ai-sdk/getting-started/package-lock.json
+++ b/ai-sdk/getting-started/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../../ai-sdk-provider": {
       "name": "@runpod/ai-sdk-provider",
-      "version": "0.8.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.11",
@@ -35,7 +35,7 @@
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^2.0.0",
-        "zod": "^3.25.0"
+        "zod": "^3.25.76"
       },
       "engines": {
         "node": ">=18"

--- a/ai-sdk/getting-started/package.json
+++ b/ai-sdk/getting-started/package.json
@@ -7,7 +7,7 @@
   "scripts": {},
   "dependencies": {
     "@ai-sdk/openai": "^2.0.13",
-    "@runpod/ai-sdk-provider": "file:/Users/timpietrusky/data/dev/runpod/ai-sdk-provider",
+    "@runpod/ai-sdk-provider": "^0.11.0",
     "ai": "^5.0.13",
     "dotenv": "^17.2.1",
     "zod": "^3.25.76"

--- a/ai-sdk/getting-started/test-gpt-oss-120b.js
+++ b/ai-sdk/getting-started/test-gpt-oss-120b.js
@@ -1,0 +1,150 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateText, streamText, tool } from "ai";
+import { z } from "zod";
+
+dotenv.config({ quiet: true });
+
+const MODEL_ID = "openai/gpt-oss-120b";
+
+console.log(`Testing model: ${MODEL_ID}`);
+console.log("Make sure RUNPOD_API_KEY is set in your .env file\n");
+
+async function testGenerateText() {
+  console.log("\n=== Testing generateText ===");
+  const startTime = Date.now();
+  try {
+    const { text, usage, finishReason } = await generateText({
+      model: runpod(MODEL_ID),
+      prompt: "Write a haiku about artificial intelligence.",
+      temperature: 0.7,
+      maxTokens: 100,
+    });
+
+    const endTime = Date.now();
+    const totalTime = (endTime - startTime) / 1000;
+    const outputTokens = usage?.outputTokens || 0;
+    const inputTokens = usage?.inputTokens || 0;
+    const tokensPerSecond =
+      outputTokens > 0 ? (outputTokens / totalTime).toFixed(2) : "N/A";
+
+    console.log("Success!");
+    console.log("Text:", text);
+    console.log("Finish reason:", finishReason);
+    console.log("\nPerformance Metrics:");
+    console.log(`  Total time: ${totalTime.toFixed(2)}s`);
+    console.log(`  Input tokens: ${inputTokens}`);
+    console.log(`  Output tokens: ${outputTokens}`);
+    console.log(`  Tokens/second: ${tokensPerSecond}`);
+  } catch (error) {
+    const endTime = Date.now();
+    const totalTime = (endTime - startTime) / 1000;
+    console.error("Failed:", error?.message || error);
+    console.error(`  Failed after: ${totalTime.toFixed(2)}s`);
+    if (error?.statusCode) {
+      console.error("  Status code:", error.statusCode);
+    }
+  }
+}
+
+async function testStreamText() {
+  console.log("\n=== Testing streamText ===");
+  const startTime = Date.now();
+  let firstTokenTime = null;
+  try {
+    const { textStream, usage } = await streamText({
+      model: runpod(MODEL_ID),
+      prompt: "Count from 1 to 5, then say done.",
+      temperature: 0.3,
+    });
+
+    console.log("Streaming...");
+    process.stdout.write("Text: ");
+    for await (const chunk of textStream) {
+      if (firstTokenTime === null) {
+        firstTokenTime = Date.now();
+      }
+      process.stdout.write(chunk);
+    }
+    process.stdout.write("\n");
+
+    const endTime = Date.now();
+    const totalTime = (endTime - startTime) / 1000;
+    const ttft = firstTokenTime
+      ? ((firstTokenTime - startTime) / 1000).toFixed(3)
+      : "N/A";
+
+    if (usage) {
+      try {
+        const usageResolved = await usage;
+        if (usageResolved) {
+          const outputTokens = usageResolved.outputTokens || 0;
+          const tokensPerSecond =
+            outputTokens > 0 ? (outputTokens / totalTime).toFixed(2) : "N/A";
+          console.log("\nPerformance Metrics:");
+          console.log(`  Time to first token (TTFT): ${ttft}s`);
+          console.log(`  Total time: ${totalTime.toFixed(2)}s`);
+          console.log(`  Output tokens: ${outputTokens}`);
+          console.log(`  Tokens/second: ${tokensPerSecond}`);
+        }
+      } catch {}
+    }
+  } catch (error) {
+    const endTime = Date.now();
+    const totalTime = (endTime - startTime) / 1000;
+    console.error("Failed:", error?.message || error);
+    console.error(`  Failed after: ${totalTime.toFixed(2)}s`);
+  }
+}
+
+async function testToolCalling() {
+  console.log("\n=== Testing Tool Calling ===");
+  const startTime = Date.now();
+  try {
+    const getWeather = tool({
+      description: "Get the current weather for a city",
+      inputSchema: z.object({
+        city: z.string().describe("The name of the city"),
+      }),
+      execute: async ({ city }) => {
+        return `The weather in ${city} is sunny, 72F with clear skies.`;
+      },
+    });
+
+    const { text, toolCalls } = await generateText({
+      model: runpod(MODEL_ID),
+      tools: { getWeather },
+      prompt: "What is the weather like in San Francisco?",
+    });
+
+    const endTime = Date.now();
+    const totalTime = (endTime - startTime) / 1000;
+
+    console.log("Success!");
+    console.log("Text:", text);
+    console.log(`Total time: ${totalTime.toFixed(2)}s`);
+    if (toolCalls && toolCalls.length > 0) {
+      console.log("Tool calls:", JSON.stringify(toolCalls, null, 2));
+      console.log(`Tool was called ${toolCalls.length} time(s)`);
+    } else {
+      console.log("No tool calls made");
+    }
+  } catch (error) {
+    const endTime = Date.now();
+    const totalTime = (endTime - startTime) / 1000;
+    console.error("Failed:", error?.message || error);
+    console.error(`  Failed after: ${totalTime.toFixed(2)}s`);
+  }
+}
+
+async function main() {
+  await testGenerateText();
+  await testStreamText();
+  await testToolCalling();
+  console.log("\n=== All tests completed ===");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Add example scripts for the new Pruna and Nano Banana Pro image models:

- `generate-image-pruna.js` - Pruna text-to-image example
- `edit-image-pruna.js` - Pruna image editing example
- `edit-image-nano-banana-pro.js` - Nano Banana Pro editing example

All examples follow the same naming conventions and patterns as existing examples in the getting-started directory.

Updated package.json to use `@runpod/ai-sdk-provider ^0.11.0`.