### PR TITLE
fix(examples): update pruna and nano banana pro examples

### DIFF
--- a/ai-sdk/getting-started/edit-image-nano-banana-pro.js
+++ b/ai-sdk/getting-started/edit-image-nano-banana-pro.js
@@ -19,13 +19,12 @@ async function main() {
   const { image } = await generateImage({
     model: runpod.imageModel("google/nano-banana-pro-edit"),
     prompt,
+    aspectRatio: "16:9",
     providerOptions: {
       runpod: {
         images: [imageUrl],
         resolution: "1k",
         output_format: "jpeg",
-        enable_base64_output: false,
-        enable_sync_mode: false,
       },
     },
   });

--- a/ai-sdk/getting-started/edit-image-pruna.js
+++ b/ai-sdk/getting-started/edit-image-pruna.js
@@ -13,14 +13,12 @@ async function main() {
 
   const { image } = await generateImage({
     model: runpod.imageModel("pruna/p-image-edit"),
-    prompt: "the lion is dressed up as santa claus, watercolor painting style",
+    prompt: "Transform the subject into a watercolor painting style",
     providerOptions: {
       runpod: {
         images: [imageUrl],
         aspect_ratio: "match_input_image",
-        seed: -1,
-        disable_safety_checker: false,
-        enable_sync_mode: false,
+        seed: 42,
       },
     },
   });

--- a/ai-sdk/getting-started/generate-image-pruna.js
+++ b/ai-sdk/getting-started/generate-image-pruna.js
@@ -11,11 +11,10 @@ async function main() {
   const { image } = await generateImage({
     model: runpod.imageModel("pruna/p-image-t2i"),
     prompt: "A majestic lion standing on a rocky cliff at sunset",
+    aspectRatio: "16:9",
     providerOptions: {
       runpod: {
-        aspect_ratio: "16:9",
-        enable_safety_checker: true,
-        seed: 0,
+        seed: 42,
       },
     },
   });

--- a/ai-sdk/getting-started/package-lock.json
+++ b/ai-sdk/getting-started/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../../ai-sdk-provider": {
       "name": "@runpod/ai-sdk-provider",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.11",


### PR DESCRIPTION
Update Pruna and Nano Banana Pro example parameters:

- Use aspectRatio param directly for cleaner API usage
- Simplify providerOptions to essential params only
- Add 16:9 aspect ratio to Nano Banana Pro example