### PR TITLE
docs: update examples to use standard AI SDK options

### DIFF
--- a/ai-sdk/getting-started/edit-image-nano-banana-pro.js
+++ b/ai-sdk/getting-started/edit-image-nano-banana-pro.js
@@ -16,6 +16,8 @@ async function main() {
     process.argv[3] ||
     "Add Christmas decorations to this cozy small town: twinkling Christmas lights along rooflines and windows, festive wreaths on front doors, Christmas trees visible through warm glowing windows, vintage street lamps wrapped in evergreen garlands with red bows, gazebo in the town square decorated with lights and ornaments, picket fences adorned with festive decorations, gentle snowfall, soft blanket of snow on rooftops and streets, warm holiday atmosphere with Christmas lights creating a magical glow, maintaining the cozy Christmas aesthetic.";
 
+  // Using standard AI SDK options where possible (aspectRatio)
+  // images, resolution, output_format need providerOptions
   const { image } = await generateImage({
     model: runpod.imageModel("google/nano-banana-pro-edit"),
     prompt,

--- a/ai-sdk/getting-started/edit-image-pruna.js
+++ b/ai-sdk/getting-started/edit-image-pruna.js
@@ -11,14 +11,16 @@ async function main() {
   const imageUrl =
     process.argv[2] || "https://image.runpod.ai/preview/pruna/p-image-t2i.png";
 
+  // Using standard AI SDK options where possible (aspectRatio, seed)
+  // images and pruna-specific aspect_ratio values need providerOptions
   const { image } = await generateImage({
     model: runpod.imageModel("pruna/p-image-edit"),
     prompt: "Transform the subject into a watercolor painting style",
+    aspectRatio: "1:1",
+    seed: 42,
     providerOptions: {
       runpod: {
         images: [imageUrl],
-        aspect_ratio: "match_input_image",
-        seed: 42,
       },
     },
   });

--- a/ai-sdk/getting-started/generate-image-pruna.js
+++ b/ai-sdk/getting-started/generate-image-pruna.js
@@ -8,15 +8,12 @@ dotenv.config({ quiet: true });
 console.log("image generation (pruna t2i) with Runpod AI SDK Provider\n");
 
 async function main() {
+  // Using standard AI SDK options (aspectRatio, seed) - no providerOptions needed
   const { image } = await generateImage({
     model: runpod.imageModel("pruna/p-image-t2i"),
     prompt: "A majestic lion standing on a rocky cliff at sunset",
     aspectRatio: "16:9",
-    providerOptions: {
-      runpod: {
-        seed: 42,
-      },
-    },
+    seed: 42,
   });
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");


### PR DESCRIPTION
Update Pruna and Nano Banana Pro examples to use standard AI SDK options:

- Use standard `aspectRatio` and `seed` params instead of `providerOptions.runpod`
- Only use `providerOptions.runpod` for model-specific params:
  - `images` (required for edit models, not available in standard AI SDK)
  - `resolution` (Nano Banana Pro specific)
  - `output_format` (Nano Banana Pro specific)
- Add comments explaining when providerOptions are needed

This makes the examples cleaner and easier to understand, following AI SDK best practices.