### PR TITLE
feat(examples): upgrade to AI SDK v6 and use prompt.images API

### DIFF
--- a/ai-sdk/getting-started/edit-image-flux.js
+++ b/ai-sdk/getting-started/edit-image-flux.js
@@ -12,12 +12,14 @@ async function main() {
     process.argv[2] || "https://image.runpod.ai/asset/qwen/qwen-image-edit.png";
 
   const { image } = await generateImage({
-    model: runpod.imageModel("black-forest-labs/flux-1-kontext-dev"),
-    prompt: "change the trench coat color to blue and high heels color to red",
+    model: runpod.image("black-forest-labs/flux-1-kontext-dev"),
+    prompt: {
+      text: "change the trench coat color to blue and high heels color to red",
+      images: [imageUrl],
+    },
     aspectRatio: "1:1",
     providerOptions: {
       runpod: {
-        image: imageUrl,
         output_format: "png",
         enable_safety_checker: true,
       },

--- a/ai-sdk/getting-started/edit-image-nano-banana-pro.js
+++ b/ai-sdk/getting-started/edit-image-nano-banana-pro.js
@@ -16,15 +16,17 @@ async function main() {
     process.argv[3] ||
     "Add Christmas decorations to this cozy small town: twinkling Christmas lights along rooflines and windows, festive wreaths on front doors, Christmas trees visible through warm glowing windows, vintage street lamps wrapped in evergreen garlands with red bows, gazebo in the town square decorated with lights and ornaments, picket fences adorned with festive decorations, gentle snowfall, soft blanket of snow on rooftops and streets, warm holiday atmosphere with Christmas lights creating a magical glow, maintaining the cozy Christmas aesthetic.";
 
-  // Using standard AI SDK options where possible (aspectRatio)
-  // images, resolution, output_format need providerOptions
+  // Using standard AI SDK options (prompt.images, aspectRatio)
+  // resolution and output_format still need providerOptions
   const { image } = await generateImage({
-    model: runpod.imageModel("google/nano-banana-pro-edit"),
-    prompt,
+    model: runpod.image("google/nano-banana-pro-edit"),
+    prompt: {
+      text: prompt,
+      images: [imageUrl],
+    },
     aspectRatio: "16:9",
     providerOptions: {
       runpod: {
-        images: [imageUrl],
         resolution: "1k",
         output_format: "jpeg",
       },

--- a/ai-sdk/getting-started/edit-image-pruna.js
+++ b/ai-sdk/getting-started/edit-image-pruna.js
@@ -11,18 +11,15 @@ async function main() {
   const imageUrl =
     process.argv[2] || "https://image.runpod.ai/preview/pruna/p-image-t2i.png";
 
-  // Using standard AI SDK options where possible (aspectRatio, seed)
-  // images and pruna-specific aspect_ratio values need providerOptions
+  // Using standard AI SDK options (prompt.images, aspectRatio, seed)
   const { image } = await generateImage({
-    model: runpod.imageModel("pruna/p-image-edit"),
-    prompt: "Transform the subject into a watercolor painting style",
+    model: runpod.image("pruna/p-image-edit"),
+    prompt: {
+      text: "Transform the subject into a watercolor painting style",
+      images: [imageUrl],
+    },
     aspectRatio: "1:1",
     seed: 42,
-    providerOptions: {
-      runpod: {
-        images: [imageUrl],
-      },
-    },
   });
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");

--- a/ai-sdk/getting-started/edit-image-qwen.js
+++ b/ai-sdk/getting-started/edit-image-qwen.js
@@ -12,12 +12,14 @@ async function main() {
     process.argv[2] || "https://image.runpod.ai/asset/qwen/qwen-image-edit.png";
 
   const { image } = await generateImage({
-    model: runpod.imageModel("qwen/qwen-image-edit"),
-    prompt: "change the trench coat and high heels color to light grey",
+    model: runpod.image("qwen/qwen-image-edit"),
+    prompt: {
+      text: "change the trench coat and high heels color to light grey",
+      images: [imageUrl],
+    },
     aspectRatio: "1:1",
     providerOptions: {
       runpod: {
-        image: imageUrl,
         output_format: "png",
         enable_safety_checker: true,
       },

--- a/ai-sdk/getting-started/edit-image-seedream-v4-base64-single.js
+++ b/ai-sdk/getting-started/edit-image-seedream-v4-base64-single.js
@@ -41,12 +41,14 @@ async function main() {
   console.log(imageDataUrl.slice(0, 30));
 
   const { image } = await generateImage({
-    model: runpod.imageModel("bytedance/seedream-4.0-edit"),
-    prompt,
+    model: runpod.image("bytedance/seedream-4.0-edit"),
+    prompt: {
+      text: prompt,
+      images: [imageDataUrl],
+    },
     size: "1024x1024",
     providerOptions: {
       runpod: {
-        images: [imageDataUrl],
         enable_safety_checker: true,
       },
     },

--- a/ai-sdk/getting-started/edit-image-seedream-v4-base64.js
+++ b/ai-sdk/getting-started/edit-image-seedream-v4-base64.js
@@ -63,12 +63,14 @@ async function main() {
   }
 
   const { image } = await generateImage({
-    model: runpod.imageModel("bytedance/seedream-4.0-edit"),
-    prompt,
+    model: runpod.image("bytedance/seedream-4.0-edit"),
+    prompt: {
+      text: prompt,
+      images,
+    },
     size: "1024x1024",
     providerOptions: {
       runpod: {
-        images,
         enable_safety_checker: true,
       },
     },

--- a/ai-sdk/getting-started/edit-image-seedream-v4.js
+++ b/ai-sdk/getting-started/edit-image-seedream-v4.js
@@ -20,12 +20,14 @@ async function main() {
   ];
 
   const { image } = await generateImage({
-    model: runpod.imageModel("bytedance/seedream-4.0-edit"),
-    prompt,
+    model: runpod.image("bytedance/seedream-4.0-edit"),
+    prompt: {
+      text: prompt,
+      images,
+    },
     size: "1024x1024",
     providerOptions: {
       runpod: {
-        images,
         enable_safety_checker: true,
       },
     },

--- a/ai-sdk/getting-started/generate-image-pruna.js
+++ b/ai-sdk/getting-started/generate-image-pruna.js
@@ -10,7 +10,7 @@ console.log("image generation (pruna t2i) with Runpod AI SDK Provider\n");
 async function main() {
   // Using standard AI SDK options (aspectRatio, seed) - no providerOptions needed
   const { image } = await generateImage({
-    model: runpod.imageModel("pruna/p-image-t2i"),
+    model: runpod.image("pruna/p-image-t2i"),
     prompt: "A majestic lion standing on a rocky cliff at sunset",
     aspectRatio: "16:9",
     seed: 42,

--- a/ai-sdk/getting-started/generate-image-seedream-v4.js
+++ b/ai-sdk/getting-started/generate-image-seedream-v4.js
@@ -13,7 +13,7 @@ async function main() {
     "American retro 1950s illustration style — an abandoned atomic-age town in ruins, cracked pavement and faded road signs, rusted 1950s cars half-buried in dust, tilted power lines, pastel-colored buildings crumbling under a hazy golden sky — soft film grain, worn paper texture, sunbeams breaking through dusty air — wisps of eerie green radiation mist drifting along the ground, faint green glow seeping from cracked windows and broken streetlamps, subtle radioactive haze hanging in the distance, wide desolate street receding into the horizon, eerie yet nostalgic atmosphere.";
 
   const { image } = await generateImage({
-    model: runpod.imageModel("bytedance/seedream-4.0"),
+    model: runpod.image("bytedance/seedream-4.0"),
     prompt,
     // This model supports large sizes; default to 2048x2048
     size: "2048x2048",

--- a/ai-sdk/getting-started/generate-image.js
+++ b/ai-sdk/getting-started/generate-image.js
@@ -9,7 +9,7 @@ console.log("image generation (Runpod AI SDK Provider)\n");
 
 async function main() {
   const { image } = await generateImage({
-    model: runpod.imageModel("black-forest-labs/flux-1-dev"),
+    model: runpod.image("pruna/p-image-t2i"),
     prompt: "A cozy cabin in the woods at golden hour, cinematic lighting",
     aspectRatio: "4:3",
   });

--- a/ai-sdk/getting-started/package.json
+++ b/ai-sdk/getting-started/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^2.0.13",
     "@runpod/ai-sdk-provider": "^0.12.0",
-    "ai": "^5.0.13",
+    "ai": "^6.0.0",
     "dotenv": "^17.2.1",
     "zod": "^3.25.76"
   }

--- a/ai-sdk/getting-started/package.json
+++ b/ai-sdk/getting-started/package.json
@@ -7,7 +7,7 @@
   "scripts": {},
   "dependencies": {
     "@ai-sdk/openai": "^2.0.13",
-    "@runpod/ai-sdk-provider": "^0.12.0",
+    "@runpod/ai-sdk-provider": "^1.0.0",
     "ai": "^6.0.0",
     "dotenv": "^17.2.1",
     "zod": "^3.25.76"

--- a/ai-sdk/getting-started/pnpm-lock.yaml
+++ b/ai-sdk/getting-started/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0(zod@3.25.76)
       ai:
-        specifier: ^5.0.13
-        version: 5.0.113(zod@3.25.76)
+        specifier: ^6.0.0
+        version: 6.0.2(zod@3.25.76)
       dotenv:
         specifier: ^17.2.1
         version: 17.2.3
@@ -26,8 +26,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@2.0.21':
-    resolution: {integrity: sha512-BwV7DU/lAm3Xn6iyyvZdWgVxgLu3SNXzl5y57gMvkW4nGhAOV5269IrJzQwGt03bb107sa6H6uJwWxc77zXoGA==}
+  '@ai-sdk/gateway@3.0.1':
+    resolution: {integrity: sha512-WyDeUe59k55lhAXAxsfdYi28IANwpAEzt8AtdA332uWPZliRfd/ccIEzMdeCuG9Z45TFMVmR1TMAenDnnJ0leQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -50,8 +50,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.0':
+    resolution: {integrity: sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.0':
+    resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
     engines: {node: '>=18'}
 
   '@opentelemetry/api@1.9.0':
@@ -67,12 +77,15 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
     engines: {node: '>= 20'}
 
-  ai@5.0.113:
-    resolution: {integrity: sha512-26vivpSO/mzZj0k1Si2IpsFspp26ttQICHRySQiMrtWcRd5mnJMX2a8sG28vmZ38C+JUn1cWmfZrsLMxkSMw9g==}
+  ai@6.0.2:
+    resolution: {integrity: sha512-LQYfHOBYDAm5y6KI6qM9WG056q8gzyfXoFxx607uHxjFGdboNqU58JpxBoo91XRJdpI/K70Qxa4VFcsWjkn9vA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -93,10 +106,10 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.21(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.1(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
       '@vercel/oidc': 3.0.5
       zod: 3.25.76
 
@@ -119,7 +132,18 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.0(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.0
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -134,13 +158,15 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@vercel/oidc@3.0.5': {}
 
-  ai@5.0.113(zod@3.25.76):
+  ai@6.0.2(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.21(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.1(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 

--- a/ai-sdk/getting-started/pnpm-lock.yaml
+++ b/ai-sdk/getting-started/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.0.13
         version: 2.0.86(zod@3.25.76)
       '@runpod/ai-sdk-provider':
-        specifier: ^0.12.0
-        version: 0.12.0(zod@3.25.76)
+        specifier: ^1.0.0
+        version: 1.0.0(zod@3.25.76)
       ai:
         specifier: ^6.0.0
         version: 6.0.2(zod@3.25.76)
@@ -32,8 +32,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@1.0.29':
-    resolution: {integrity: sha512-cZUppWzxjfpNaH1oVZ6U8yDLKKsdGbC9X0Pex8cG9CXhKWSoVLLnW1rKr6tu9jDISK5okjBIW/O1ZzfnbUrtEw==}
+  '@ai-sdk/openai-compatible@2.0.0':
+    resolution: {integrity: sha512-dQITHbDWLtIVB0Kpb9AXRMAZC2n4azS2T/uaVq8HOgw2Uy9x19usS0DIoXlTbj3R4rJuJXpAUhYowQ+YcK16WQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -68,8 +68,8 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@runpod/ai-sdk-provider@0.12.0':
-    resolution: {integrity: sha512-Wa+1BnzB/XtmGZBO4x22U8wsjiK4ylyNpwMC1RYf1mRS6W6h7qAlq2tDy39lF4CRWFHa7FZn0tad4wkFqDiHKA==}
+  '@runpod/ai-sdk-provider@1.0.0':
+    resolution: {integrity: sha512-Jx0JsQxjPjne6A4i0Wqpt/E04u4yzhl66CCH+JqxDJgzBilPZOyGWdHr71U/f7frkhQJkKl66Q9kdmTLVqjQ9A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
@@ -113,10 +113,10 @@ snapshots:
       '@vercel/oidc': 3.0.5
       zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@1.0.29(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@2.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/openai@2.0.86(zod@3.25.76)':
@@ -149,11 +149,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@runpod/ai-sdk-provider@0.12.0(zod@3.25.76)':
+  '@runpod/ai-sdk-provider@1.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.29(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 2.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
       zod: 3.25.76
 
   '@standard-schema/spec@1.0.0': {}

--- a/ai-sdk/getting-started/test-error-handling.js
+++ b/ai-sdk/getting-started/test-error-handling.js
@@ -36,7 +36,7 @@ async function testImageErrorInvalidSize() {
   console.log("2. Testing image model error (unsupported size)...");
   try {
     await generateImage({
-      model: runpod.imageModel("black-forest-labs/flux-1-dev"),
+      model: runpod.image("black-forest-labs/flux-1-dev"),
       prompt: "A test image",
       size: "9999x9999", // Invalid size
     });
@@ -52,7 +52,7 @@ async function testImageErrorInvalidModel() {
   console.log("3. Testing image model error (invalid model ID)...");
   try {
     await generateImage({
-      model: runpod.imageModel("nonexistent/model-id"),
+      model: runpod.image("nonexistent/model-id"),
       prompt: "A test image",
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

Updates all examples to use AI SDK v6 and the new provider API patterns:

- **API modernization**: All examples now use `runpod.image()` alias instead of `runpod.imageModel()`
- **Recommended image input**: Image edit examples migrated from `providerOptions.runpod.images/image` to `prompt.images` (AI SDK v6 standard)
- **Dependencies**: Upgraded `ai` package from v5 to v6, updated `@runpod/ai-sdk-provider` to use npm version `^0.12.0`
- **Model updates**: `generate-image.js` now uses `pruna/p-image-t2i` (modern fast model) instead of legacy Flux

All examples tested and working with the v6 provider.