### PR TITLE
feat(ai-sdk): add new image model examples

### DIFF
--- a/ai-sdk/getting-started/edit-image-qwen-image-edit-2511-lora.js
+++ b/ai-sdk/getting-started/edit-image-qwen-image-edit-2511-lora.js
@@ -1,0 +1,39 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("edit-image-qwen-image-edit-2511-lora\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.image("qwen/qwen-image-edit-2511"),
+    prompt: "Transform into anime style, vibrant colors, detailed illustration",
+    size: "1024x1024",
+    providerOptions: {
+      runpod: {
+        images: ["https://image.runpod.ai/asset/qwen/qwen-image-edit-2511.png"],
+        loras: [
+          {
+            path: "https://huggingface.co/flymy-ai/qwen-image-anime-irl-lora/resolve/main/flymy_anime_irl.safetensors",
+            scale: 1,
+          },
+        ],
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `edited-image-qwen-2511-lora-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/edit-image-qwen-image-edit-2511.js
+++ b/ai-sdk/getting-started/edit-image-qwen-image-edit-2511.js
@@ -1,0 +1,34 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("edit-image-qwen-image-edit-2511\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.image("qwen/qwen-image-edit-2511"),
+    prompt:
+      "A futuristic city with a slightly dark neon atmosphere and glowing street lights. The girl in the foreground, her face and body well lit by the street lighting",
+    size: "1024x1024",
+    providerOptions: {
+      runpod: {
+        images: ["https://image.runpod.ai/asset/qwen/qwen-image-edit-2511.png"],
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `edited-image-qwen-2511-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/generate-image-alibaba-wan-2.6.js
+++ b/ai-sdk/getting-started/generate-image-alibaba-wan-2.6.js
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("generate-image-alibaba-wan-2.6\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.image("alibaba/wan-2.6"),
+    prompt:
+      'A spectacular complete Chinese dragon sculpture made of neon light tubes, full body visible from head to flowing tail, positioned behind a large street-level neon sign reading "WAN 2.6" in bright cyan and magenta, cyberpunk city background, wet streets reflecting all the neon colors, the dragon wraps gracefully but its entire form is visible, photorealistic, cinematic lighting. Negative prompt: incomplete, cropped, blurry',
+    size: "1280x1280",
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `generated-image-alibaba-wan-2.6-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds examples for new image models using the Runpod AI SDK provider.

## New Examples

### Alibaba WAN 2.6 (Text-to-Image)
- `generate-image-alibaba-wan-2.6.js`
- Uses 1280x1280 resolution
- Example generates a neon dragon with 'WAN 2.6' text in cyberpunk style

### Qwen Image Edit 2511
- `edit-image-qwen-image-edit-2511.js` - Basic image editing
- `edit-image-qwen-image-edit-2511-lora.js` - With LoRA adapter support (anime style)