### PR TITLE
feat: add transcription examples for pruna/whisper-v3-large

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ node_modules
 generated-image*
 edited-image*
 *.mp4
+*.wav
 
 # mastra
 mastra.db

--- a/ai-sdk/getting-started/edit-image-qwen-image-edit-2511-lora.js
+++ b/ai-sdk/getting-started/edit-image-qwen-image-edit-2511-lora.js
@@ -1,0 +1,39 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("edit-image-qwen-image-edit-2511-lora\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.image("qwen/qwen-image-edit-2511"),
+    prompt: "Transform into anime style, vibrant colors, detailed illustration",
+    size: "1024x1024",
+    providerOptions: {
+      runpod: {
+        images: ["https://image.runpod.ai/asset/qwen/qwen-image-edit-2511.png"],
+        loras: [
+          {
+            path: "https://huggingface.co/flymy-ai/qwen-image-anime-irl-lora/resolve/main/flymy_anime_irl.safetensors",
+            scale: 1,
+          },
+        ],
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `edited-image-qwen-2511-lora-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/edit-image-qwen-image-edit-2511.js
+++ b/ai-sdk/getting-started/edit-image-qwen-image-edit-2511.js
@@ -1,0 +1,34 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("edit-image-qwen-image-edit-2511\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.image("qwen/qwen-image-edit-2511"),
+    prompt:
+      "A futuristic city with a slightly dark neon atmosphere and glowing street lights. The girl in the foreground, her face and body well lit by the street lighting",
+    size: "1024x1024",
+    providerOptions: {
+      runpod: {
+        images: ["https://image.runpod.ai/asset/qwen/qwen-image-edit-2511.png"],
+      },
+    },
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `edited-image-qwen-2511-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/generate-image-alibaba-wan-2.6.js
+++ b/ai-sdk/getting-started/generate-image-alibaba-wan-2.6.js
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { generateImage } from "ai";
+import { writeFileSync } from "fs";
+
+dotenv.config({ quiet: true });
+
+console.log("generate-image-alibaba-wan-2.6\n");
+
+async function main() {
+  const { image } = await generateImage({
+    model: runpod.image("alibaba/wan-2.6"),
+    prompt:
+      'A spectacular complete Chinese dragon sculpture made of neon light tubes, full body visible from head to flowing tail, positioned behind a large street-level neon sign reading "WAN 2.6" in bright cyan and magenta, cyberpunk city background, wet streets reflecting all the neon colors, the dragon wraps gracefully but its entire form is visible, photorealistic, cinematic lighting. Negative prompt: incomplete, cropped, blurry',
+    size: "1280x1280",
+  });
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `generated-image-alibaba-wan-2.6-${timestamp}.jpg`;
+
+  writeFileSync(filename, image.uint8Array);
+  console.log(`saved image: ${filename}`);
+  console.log(`size: ${(image.uint8Array.length / 1024).toFixed(1)}KB`);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/generate-speech-chatterbox-turbo.js
+++ b/ai-sdk/getting-started/generate-speech-chatterbox-turbo.js
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 import { writeFileSync } from "fs";
 import { runpod } from "@runpod/ai-sdk-provider";
-import { generateSpeech } from "ai";
+import { experimental_generateSpeech as generateSpeech } from "ai";
 
 dotenv.config({ quiet: true });
 

--- a/ai-sdk/getting-started/generate-transcription-demo-audio.js
+++ b/ai-sdk/getting-started/generate-transcription-demo-audio.js
@@ -1,0 +1,38 @@
+import dotenv from "dotenv";
+import { writeFileSync } from "fs";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { experimental_generateSpeech as generateSpeech } from "ai";
+
+dotenv.config({ quiet: true });
+
+// This is the text we'll generate and then transcribe back
+const DEMO_TEXT = `Welcome to Runpod. This is a demonstration of the Whisper transcription model.
+Whisper can accurately transcribe speech in over 90 languages.
+Let's see how well it works with this audio sample.`;
+
+async function main() {
+  console.log("Generating demo audio for transcription testing...");
+  console.log("Text:", DEMO_TEXT);
+
+  const { audio, providerMetadata, warnings } = await generateSpeech({
+    model: runpod.speech("resembleai/chatterbox-turbo"),
+    voice: "abigail",
+    text: DEMO_TEXT,
+  });
+
+  const filename = "transcription-demo.wav";
+  writeFileSync(filename, audio.uint8Array);
+
+  console.log("\nSaved:", filename);
+  console.log("File size:", audio.uint8Array.length, "bytes");
+  console.log("providerMetadata:", providerMetadata);
+  console.log("warnings:", warnings);
+  console.log("\nNext steps:");
+  console.log("1. Upload to R2: cd /Users/timpietrusky/data/dev/runpod/r2 && bun run cli.ts u ../examples/ai-sdk/getting-started/transcription-demo.wav demo/transcription-demo.wav");
+  console.log("2. Get public URL: bun run cli.ts url demo/transcription-demo.wav");
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/transcribe-audio-file.js
+++ b/ai-sdk/getting-started/transcribe-audio-file.js
@@ -1,0 +1,59 @@
+import dotenv from "dotenv";
+import { readFileSync } from "fs";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { experimental_transcribe as transcribe } from "ai";
+
+dotenv.config({ quiet: true });
+
+/**
+ * Transcribe audio from a local file using RunPod's Whisper model.
+ *
+ * This example demonstrates transcription using a local audio file.
+ * The file is read as a Uint8Array and sent to the API as base64.
+ */
+async function main() {
+  const filePath = "transcription-demo.wav";
+
+  console.log("Reading audio file...");
+  console.log("File:", filePath);
+
+  // Read the file as a Uint8Array
+  const audioBuffer = readFileSync(filePath);
+  const audioData = new Uint8Array(audioBuffer);
+
+  console.log("File size:", audioData.length, "bytes");
+  console.log("");
+  console.log("Transcribing...");
+  console.log("");
+
+  const result = await transcribe({
+    model: runpod.transcription("pruna/whisper-v3-large"),
+    audio: audioData,
+    providerOptions: {
+      runpod: {
+        // Optional: specify language for better accuracy
+        // language: "en",
+      },
+    },
+  });
+
+  console.log("Transcription:");
+  console.log(result.text);
+  console.log("");
+  console.log("Language:", result.language);
+  console.log("Duration:", result.durationInSeconds, "seconds");
+  console.log("Segments:", result.segments?.length || 0);
+
+  if (result.segments && result.segments.length > 0) {
+    console.log("");
+    console.log("Segment details:");
+    result.segments.forEach((seg, i) => {
+      console.log(`  [${seg.startSecond.toFixed(2)}s - ${seg.endSecond.toFixed(2)}s] ${seg.text}`);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});

--- a/ai-sdk/getting-started/transcribe-audio-url.js
+++ b/ai-sdk/getting-started/transcribe-audio-url.js
@@ -1,0 +1,45 @@
+import dotenv from "dotenv";
+import { runpod } from "@runpod/ai-sdk-provider";
+import { experimental_transcribe as transcribe } from "ai";
+
+dotenv.config({ quiet: true });
+
+/**
+ * Transcribe audio from a URL using RunPod's Whisper model.
+ *
+ * This example demonstrates transcription using an audio URL.
+ * The URL is passed via providerOptions.runpod.audio.
+ */
+async function main() {
+  const audioUrl = "https://image.runpod.ai/demo/transcription-demo.wav";
+
+  console.log("Transcribing audio from URL...");
+  console.log("URL:", audioUrl);
+  console.log("");
+
+  const result = await transcribe({
+    model: runpod.transcription("pruna/whisper-v3-large"),
+    // Note: When passing a URL, use new URL() - strings are interpreted as base64
+    audio: new URL(audioUrl),
+    providerOptions: {
+      runpod: {
+        // Pass the audio URL directly to RunPod (avoids downloading and re-uploading)
+        audio: audioUrl,
+      },
+    },
+  });
+
+  console.log("Transcription:");
+  console.log(result.text);
+  console.log("");
+  console.log("Language:", result.language);
+  console.log("Duration:", result.durationInSeconds, "seconds");
+  console.log("Segments:", result.segments?.length || 0);
+  console.log("");
+  console.log("Provider metadata:", result.providerMetadata);
+}
+
+main().catch((err) => {
+  console.error("failed:", err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Add transcription examples using the new `pruna/whisper-v3-large` model.

**Note: This is a draft PR.** The `@runpod/ai-sdk-provider` package needs to be released first with transcription support.

## New Examples
- `transcribe-audio-url.js` - Transcribe audio from a URL
- `transcribe-audio-file.js` - Transcribe audio from a local file (base64)
- `generate-transcription-demo-audio.js` - Generate demo audio for testing

## Also Fixed
- `generate-speech-chatterbox-turbo.js` - Fixed import to use `experimental_generateSpeech`
- `.gitignore` - Added `*.wav` to ignore generated audio files

## Demo Audio
Uploaded to R2: https://image.runpod.ai/demo/transcription-demo.wav

## Test plan
- [ ] Wait for `@runpod/ai-sdk-provider` release with transcription support
- [ ] Update package.json to use released version
- [ ] Run `node transcribe-audio-url.js`
- [ ] Run `node transcribe-audio-file.js`